### PR TITLE
Fix a FileNotFoundError during build

### DIFF
--- a/py2exe/runtime.py
+++ b/py2exe/runtime.py
@@ -535,7 +535,7 @@ class Runtime(object):
             else:
                 extdlldir = destdir            
             dst = os.path.join(extdlldir, name)
-            os.makedirs(os.path.dirname(extdlldir), exist_ok=True)
+            os.makedirs(os.path.dirname(dst), exist_ok=True)
             if self.options.verbose:
                 print("Copy lib file %s to %s" % (src, extdlldir))
             shutil.copy2(src, dst)


### PR DESCRIPTION
os.path.dirname(extdlldir) when extdlldir is "dist" results in an empty string like in the example below.
Fix passing the full path.

Traceback (most recent call last):
  File "C:\Program Files\Python37\lib\runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "C:\Program Files\Python37\lib\runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "c:\src\Pytnon37_x64\lib\site-packages\py2exe\build_exe.py", line 145, in <module>
    main()
  File "c:\src\Pytnon37_x64\lib\site-packages\py2exe\build_exe.py", line 142, in main
    builder.build()
  File "c:\src\Pytnon37_x64\lib\site-packages\py2exe\runtime.py", line 264, in build
    self.copy_files(destdir)
  File "c:\src\Pytnon37_x64\lib\site-packages\py2exe\runtime.py", line 535, in copy_files
    os.makedirs(os.path.dirname(extdlldir), exist_ok=True)
  File "C:\Program Files\Python37\lib\os.py", line 221, in makedirs
    mkdir(name, mode)
FileNotFoundError: [WinError 3] Impossibile trovare il percorso specificato: ''