### PR TITLE
Fix ssl.SSLError issue when bundle_files=0

### DIFF
--- a/py2exe/hooks.py
+++ b/py2exe/hooks.py
@@ -645,8 +645,6 @@ def hook__ssl(finder, module):
     On Python 3.7 and above, _ssl.pyd requires additional dll's to load.
     Based on code by Sebastian Krause: https://github.com/anthony-tuininga/cx_Freeze/pull/470
     Apparently, even with the new DLL finder system, this hook is still needed on cp37-win32
-
-    On Python 3.7 an above, _ssl is incompatible with bundle_files=0.
     """
     if sys.version_info < (3, 7, 0):
         return
@@ -656,5 +654,3 @@ def hook__ssl(finder, module):
         for dll_path in glob.glob(os.path.join(sys.base_prefix, "DLLs", dll_search)):
             dll_name = os.path.basename(dll_path)
             finder.add_dll(dll_path)
-
-    finder.set_min_bundle("_ssl", 1)

--- a/source/MyLoadLibrary.c
+++ b/source/MyLoadLibrary.c
@@ -235,6 +235,15 @@ BOOL MyFreeLibrary(HMODULE module)
 	}
 }
 
+BOOL WINAPI MyGetModuleHandleExW(DWORD flags, LPCWSTR modname, HMODULE *pmodule) 
+{
+	if (flags & GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS && pmodule != NULL) {
+		*pmodule = GetModuleHandle(NULL);
+		return TRUE;
+	}
+	return GetModuleHandleExW(flags, modname, pmodule);
+}
+
 FARPROC MyGetProcAddress(HMODULE module, LPCSTR procname)
 {
 	FARPROC proc;
@@ -244,6 +253,8 @@ FARPROC MyGetProcAddress(HMODULE module, LPCSTR procname)
 	else {
 		SetLastError(0);
 		proc = GetProcAddress(module, procname);
+		if (proc == &GetModuleHandleExW)
+			proc = (FARPROC)MyGetModuleHandleExW;
 	}
 	return proc;
 }


### PR DESCRIPTION
Hello.

As mentioned in #65, current py2exe with bundle_files=0 has not working properly on  Python 3.7 or later. 
It caused by that _ssl.pyd module uses GetModuleHandleExW() call with GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS that _memimport(MemoryModule) does not support. (Refer https://github.com/openssl/openssl/blob/c8c6e7438c03b2fc24e7ead460feeaef04911fb4/crypto/init.c#L172-L174, and OpenSSL 1.0.2g which is used by Python 3.6 does not use GetModuleHandleExW()) 

In order to resolve #65, I add MyGetModuleHandleExW() and hook calling to prevent SSL initialization failure.
