### PR TITLE
Update MemoryModule to the latest version

### DIFF
--- a/source/MemoryModule.c
+++ b/source/MemoryModule.c
@@ -1,8 +1,8 @@
 /*
  * Memory DLL loading code
- * Version 0.0.3
+ * Version 0.0.4
  *
- * Copyright (c) 2004-2013 by Joachim Bauch / mail@joachim-bauch.de
+ * Copyright (c) 2004-2015 by Joachim Bauch / mail@joachim-bauch.de
  * http://www.joachim-bauch.de
  *
  * The contents of this file are subject to the Mozilla Public License Version
@@ -19,7 +19,7 @@
  *
  * The Initial Developer of the Original Code is Joachim Bauch.
  *
- * Portions created by Joachim Bauch are Copyright (C) 2004-2013
+ * Portions created by Joachim Bauch are Copyright (C) 2004-2015
  * Joachim Bauch. All Rights Reserved.
  *
  *
@@ -30,42 +30,51 @@
  * These portions are Copyright (C) 2013 Thomas Heller.
  */
 
-// #define DEBUG_OUTPUT /* enable to print debug output */
-
-#ifndef __GNUC__
-// disable warnings about pointer <-> DWORD conversions
-#pragma warning( disable : 4311 4312 )
-#endif
-
-#ifdef _WIN64
-#define POINTER_TYPE ULONGLONG
-#else
-#define POINTER_TYPE DWORD
-#endif
-
 #include <windows.h>
 #include <winnt.h>
+#include <stddef.h>
 #include <tchar.h>
 #ifdef DEBUG_OUTPUT
 #include <stdio.h>
 #endif
 
-// XXX SetLastErrorString(err, "foo") ???
+#if _MSC_VER
+// Disable warning about data -> function pointer conversion
+#pragma warning(disable:4055)
+ // C4244: conversion from 'uintptr_t' to 'DWORD', possible loss of data.
+#pragma warning(error: 4244)
+// C4267: conversion from 'size_t' to 'int', possible loss of data.
+#pragma warning(error: 4267)
+
+#define inline __inline
+#endif
 
 #ifndef IMAGE_SIZEOF_BASE_RELOCATION
 // Vista SDKs no longer define IMAGE_SIZEOF_BASE_RELOCATION!?
 #define IMAGE_SIZEOF_BASE_RELOCATION (sizeof(IMAGE_BASE_RELOCATION))
 #endif
 
+#ifdef _WIN64
+#define HOST_MACHINE IMAGE_FILE_MACHINE_AMD64
+#else
+#define HOST_MACHINE IMAGE_FILE_MACHINE_I386
+#endif
+
 #include "MemoryModule.h"
 
-#ifdef USE_BINARY_SEARCH
-
-struct NAME_TABLE {
+struct ExportNameEntry {
     LPCSTR name;
     WORD idx;
 };
 
+typedef BOOL (WINAPI *DllEntryProc)(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpReserved);
+typedef int (WINAPI *ExeEntryProc)(void);
+
+#ifdef _WIN64
+typedef struct POINTER_LIST {
+    struct POINTER_LIST *next;
+    void *address;
+} POINTER_LIST;
 #endif
 
 typedef struct {
@@ -73,25 +82,59 @@ typedef struct {
     unsigned char *codeBase;
     HCUSTOMMODULE *modules;
     int numModules;
-    int initialized;
+    BOOL initialized;
+    BOOL isDLL;
+    BOOL isRelocated;
+    CustomAllocFunc alloc;
+    CustomFreeFunc free;
     CustomLoadLibraryFunc loadLibrary;
     CustomGetProcAddressFunc getProcAddress;
     CustomFreeLibraryFunc freeLibrary;
-#ifdef USE_BINARY_SEARCH
-    struct NAME_TABLE *name_table;
-    int numEntries;
-#endif
+    struct ExportNameEntry *nameExportsTable;
     void *userdata;
+    ExeEntryProc exeEntry;
+    DWORD pageSize;
+#ifdef _WIN64
+    POINTER_LIST *blockedMemory;
+#endif
 } MEMORYMODULE, *PMEMORYMODULE;
 
-typedef BOOL (WINAPI *DllEntryProc)(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpReserved);
+typedef struct {
+    LPVOID address;
+    LPVOID alignedAddress;
+    SIZE_T size;
+    DWORD characteristics;
+    BOOL last;
+} SECTIONFINALIZEDATA, *PSECTIONFINALIZEDATA;
 
-#define GET_HEADER_DICTIONARY(module, idx)	&(module)->headers->OptionalHeader.DataDirectory[idx]
+#define GET_HEADER_DICTIONARY(module, idx)  &(module)->headers->OptionalHeader.DataDirectory[idx]
 
-#ifdef DEBUG_OUTPUT
-static void
+static inline uintptr_t
+AlignValueDown(uintptr_t value, uintptr_t alignment) {
+    return value & ~(alignment - 1);
+}
+
+static inline LPVOID
+AlignAddressDown(LPVOID address, uintptr_t alignment) {
+    return (LPVOID) AlignValueDown((uintptr_t) address, alignment);
+}
+
+static inline size_t
+AlignValueUp(size_t value, size_t alignment) {
+    return (value + alignment - 1) & ~(alignment - 1);
+}
+
+static inline void*
+OffsetPointer(void* data, ptrdiff_t offset) {
+    return (void*) ((uintptr_t) data + offset);
+}
+
+static inline void
 OutputLastError(const char *msg)
 {
+#ifndef DEBUG_OUTPUT
+    UNREFERENCED_PARAMETER(msg);
+#else
     LPVOID tmp;
     char *tmpmsg;
     FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
@@ -101,13 +144,38 @@ OutputLastError(const char *msg)
     OutputDebugString(tmpmsg);
     LocalFree(tmpmsg);
     LocalFree(tmp);
+#endif
+}
+
+#ifdef _WIN64
+static void
+FreePointerList(POINTER_LIST *head, CustomFreeFunc freeMemory, void *userdata)
+{
+    POINTER_LIST *node = head;
+    while (node) {
+        POINTER_LIST *next;
+        freeMemory(node->address, 0, MEM_RELEASE, userdata);
+        next = node->next;
+        free(node);
+        node = next;
+    }
 }
 #endif
 
-static void
-CopySections(const unsigned char *data, PIMAGE_NT_HEADERS old_headers, PMEMORYMODULE module)
+static BOOL
+CheckSize(size_t size, size_t expected) {
+    if (size < expected) {
+        SetLastError(ERROR_INVALID_DATA);
+        return FALSE;
+    }
+
+    return TRUE;
+}
+
+static BOOL
+CopySections(const unsigned char *data, size_t size, PIMAGE_NT_HEADERS old_headers, PMEMORYMODULE module)
 {
-    int i, size;
+    int i, section_size;
     unsigned char *codeBase = module->codeBase;
     unsigned char *dest;
     PIMAGE_SECTION_HEADER section = IMAGE_FIRST_SECTION(module->headers);
@@ -115,29 +183,54 @@ CopySections(const unsigned char *data, PIMAGE_NT_HEADERS old_headers, PMEMORYMO
         if (section->SizeOfRawData == 0) {
             // section doesn't contain data in the dll itself, but may define
             // uninitialized data
-            size = old_headers->OptionalHeader.SectionAlignment;
-            if (size > 0) {
-                dest = (unsigned char *)VirtualAlloc(codeBase + section->VirtualAddress,
-                    size,
+            section_size = old_headers->OptionalHeader.SectionAlignment;
+            if (section_size > 0) {
+                dest = (unsigned char *)module->alloc(codeBase + section->VirtualAddress,
+                    section_size,
                     MEM_COMMIT,
-                    PAGE_READWRITE);
+                    PAGE_READWRITE,
+                    module->userdata);
+                if (dest == NULL) {
+                    return FALSE;
+                }
 
-                section->Misc.PhysicalAddress = (DWORD) (POINTER_TYPE) dest;
-                memset(dest, 0, size);
+                // Always use position from file to support alignments smaller
+                // than page size (allocation above will align to page size).
+                dest = codeBase + section->VirtualAddress;
+                // NOTE: On 64bit systems we truncate to 32bit here but expand
+                // again later when "PhysicalAddress" is used.
+                section->Misc.PhysicalAddress = (DWORD) ((uintptr_t) dest & 0xffffffff);
+                memset(dest, 0, section_size);
             }
 
             // section is empty
             continue;
         }
 
+        if (!CheckSize(size, section->PointerToRawData + section->SizeOfRawData)) {
+            return FALSE;
+        }
+
         // commit memory block and copy data from dll
-        dest = (unsigned char *)VirtualAlloc(codeBase + section->VirtualAddress,
+        dest = (unsigned char *)module->alloc(codeBase + section->VirtualAddress,
                             section->SizeOfRawData,
                             MEM_COMMIT,
-                            PAGE_READWRITE);
+                            PAGE_READWRITE,
+                            module->userdata);
+        if (dest == NULL) {
+            return FALSE;
+        }
+
+        // Always use position from file to support alignments smaller
+        // than page size (allocation above will align to page size).
+        dest = codeBase + section->VirtualAddress;
         memcpy(dest, data + section->PointerToRawData, section->SizeOfRawData);
-        section->Misc.PhysicalAddress = (DWORD) (POINTER_TYPE) dest;
+        // NOTE: On 64bit systems we truncate to 32bit here but expand
+        // again later when "PhysicalAddress" is used.
+        section->Misc.PhysicalAddress = (DWORD) ((uintptr_t) dest & 0xffffffff);
     }
+
+    return TRUE;
 }
 
 // Protection flags for memory pages (Executable, Readable, Writeable)
@@ -153,198 +246,277 @@ static int ProtectionFlags[2][2][2] = {
     },
 };
 
-static void
+static SIZE_T
+GetRealSectionSize(PMEMORYMODULE module, PIMAGE_SECTION_HEADER section) {
+    DWORD size = section->SizeOfRawData;
+    if (size == 0) {
+        if (section->Characteristics & IMAGE_SCN_CNT_INITIALIZED_DATA) {
+            size = module->headers->OptionalHeader.SizeOfInitializedData;
+        } else if (section->Characteristics & IMAGE_SCN_CNT_UNINITIALIZED_DATA) {
+            size = module->headers->OptionalHeader.SizeOfUninitializedData;
+        }
+    }
+    return (SIZE_T) size;
+}
+
+static BOOL
+FinalizeSection(PMEMORYMODULE module, PSECTIONFINALIZEDATA sectionData) {
+    DWORD protect, oldProtect;
+    BOOL executable;
+    BOOL readable;
+    BOOL writeable;
+
+    if (sectionData->size == 0) {
+        return TRUE;
+    }
+
+    if (sectionData->characteristics & IMAGE_SCN_MEM_DISCARDABLE) {
+        // section is not needed any more and can safely be freed
+        if (sectionData->address == sectionData->alignedAddress &&
+            (sectionData->last ||
+             module->headers->OptionalHeader.SectionAlignment == module->pageSize ||
+             (sectionData->size % module->pageSize) == 0)
+           ) {
+            // Only allowed to decommit whole pages
+            module->free(sectionData->address, sectionData->size, MEM_DECOMMIT, module->userdata);
+        }
+        return TRUE;
+    }
+
+    // determine protection flags based on characteristics
+    executable = (sectionData->characteristics & IMAGE_SCN_MEM_EXECUTE) != 0;
+    readable =   (sectionData->characteristics & IMAGE_SCN_MEM_READ) != 0;
+    writeable =  (sectionData->characteristics & IMAGE_SCN_MEM_WRITE) != 0;
+    protect = ProtectionFlags[executable][readable][writeable];
+    if (sectionData->characteristics & IMAGE_SCN_MEM_NOT_CACHED) {
+        protect |= PAGE_NOCACHE;
+    }
+
+    // change memory access flags
+    if (VirtualProtect(sectionData->address, sectionData->size, protect, &oldProtect) == 0) {
+        OutputLastError("Error protecting memory page");
+        return FALSE;
+    }
+
+    return TRUE;
+}
+
+static BOOL
 FinalizeSections(PMEMORYMODULE module)
 {
     int i;
     PIMAGE_SECTION_HEADER section = IMAGE_FIRST_SECTION(module->headers);
 #ifdef _WIN64
-    POINTER_TYPE imageOffset = (module->headers->OptionalHeader.ImageBase & 0xffffffff00000000);
+    // "PhysicalAddress" might have been truncated to 32bit above, expand to
+    // 64bits again.
+    uintptr_t imageOffset = ((uintptr_t) module->headers->OptionalHeader.ImageBase & 0xffffffff00000000);
 #else
-    #define imageOffset 0
+    static const uintptr_t imageOffset = 0;
 #endif
+    SECTIONFINALIZEDATA sectionData;
+    sectionData.address = (LPVOID)((uintptr_t)section->Misc.PhysicalAddress | imageOffset);
+    sectionData.alignedAddress = AlignAddressDown(sectionData.address, module->pageSize);
+    sectionData.size = GetRealSectionSize(module, section);
+    sectionData.characteristics = section->Characteristics;
+    sectionData.last = FALSE;
+    section++;
 
     // loop through all sections and change access flags
-    for (i=0; i<module->headers->FileHeader.NumberOfSections; i++, section++) {
-        DWORD protect, oldProtect, size;
-        int executable = (section->Characteristics & IMAGE_SCN_MEM_EXECUTE) != 0;
-        int readable =   (section->Characteristics & IMAGE_SCN_MEM_READ) != 0;
-        int writeable =  (section->Characteristics & IMAGE_SCN_MEM_WRITE) != 0;
-
-        if (section->Characteristics & IMAGE_SCN_MEM_DISCARDABLE) {
-            // section is not needed any more and can safely be freed
-            VirtualFree((LPVOID)((POINTER_TYPE)section->Misc.PhysicalAddress | imageOffset), section->SizeOfRawData, MEM_DECOMMIT);
+    for (i=1; i<module->headers->FileHeader.NumberOfSections; i++, section++) {
+        LPVOID sectionAddress = (LPVOID)((uintptr_t)section->Misc.PhysicalAddress | imageOffset);
+        LPVOID alignedAddress = AlignAddressDown(sectionAddress, module->pageSize);
+        SIZE_T sectionSize = GetRealSectionSize(module, section);
+        // Combine access flags of all sections that share a page
+        // TODO(fancycode): We currently share flags of a trailing large section
+        //   with the page of a first small section. This should be optimized.
+        if (sectionData.alignedAddress == alignedAddress || (uintptr_t) sectionData.address + sectionData.size > (uintptr_t) alignedAddress) {
+            // Section shares page with previous
+            if ((section->Characteristics & IMAGE_SCN_MEM_DISCARDABLE) == 0 || (sectionData.characteristics & IMAGE_SCN_MEM_DISCARDABLE) == 0) {
+                sectionData.characteristics = (sectionData.characteristics | section->Characteristics) & ~IMAGE_SCN_MEM_DISCARDABLE;
+            } else {
+                sectionData.characteristics |= section->Characteristics;
+            }
+            sectionData.size = (((uintptr_t)sectionAddress) + ((uintptr_t) sectionSize)) - (uintptr_t) sectionData.address;
             continue;
         }
 
-        // determine protection flags based on characteristics
-        protect = ProtectionFlags[executable][readable][writeable];
-        if (section->Characteristics & IMAGE_SCN_MEM_NOT_CACHED) {
-            protect |= PAGE_NOCACHE;
+        if (!FinalizeSection(module, &sectionData)) {
+            return FALSE;
         }
-
-        // determine size of region
-        size = section->SizeOfRawData;
-        if (size == 0) {
-            if (section->Characteristics & IMAGE_SCN_CNT_INITIALIZED_DATA) {
-                size = module->headers->OptionalHeader.SizeOfInitializedData;
-            } else if (section->Characteristics & IMAGE_SCN_CNT_UNINITIALIZED_DATA) {
-                size = module->headers->OptionalHeader.SizeOfUninitializedData;
-            }
-        }
-
-        if (size > 0) {
-            // change memory access flags
-            if (VirtualProtect((LPVOID)((POINTER_TYPE)section->Misc.PhysicalAddress | imageOffset), size, protect, &oldProtect) == 0)
-#ifdef DEBUG_OUTPUT
-                OutputLastError("Error protecting memory page")
-#endif
-            ;
-        }
+        sectionData.address = sectionAddress;
+        sectionData.alignedAddress = alignedAddress;
+        sectionData.size = sectionSize;
+        sectionData.characteristics = section->Characteristics;
     }
-#ifndef _WIN64
-#undef imageOffset
-#endif
+    sectionData.last = TRUE;
+    if (!FinalizeSection(module, &sectionData)) {
+        return FALSE;
+    }
+    return TRUE;
 }
 
-static void
+static BOOL
 ExecuteTLS(PMEMORYMODULE module)
 {
     unsigned char *codeBase = module->codeBase;
+    PIMAGE_TLS_DIRECTORY tls;
+    PIMAGE_TLS_CALLBACK* callback;
 
     PIMAGE_DATA_DIRECTORY directory = GET_HEADER_DICTIONARY(module, IMAGE_DIRECTORY_ENTRY_TLS);
-    if (directory->VirtualAddress > 0) {
-        PIMAGE_TLS_DIRECTORY tls = (PIMAGE_TLS_DIRECTORY) (codeBase + directory->VirtualAddress);
-        PIMAGE_TLS_CALLBACK* callback = (PIMAGE_TLS_CALLBACK *) tls->AddressOfCallBacks;
-        if (callback) {
-            while (*callback) {
-                (*callback)((LPVOID) codeBase, DLL_PROCESS_ATTACH, NULL);
-                callback++;
-            }
+    if (directory->VirtualAddress == 0) {
+        return TRUE;
+    }
+
+    tls = (PIMAGE_TLS_DIRECTORY) (codeBase + directory->VirtualAddress);
+    callback = (PIMAGE_TLS_CALLBACK *) tls->AddressOfCallBacks;
+    if (callback) {
+        while (*callback) {
+            (*callback)((LPVOID) codeBase, DLL_PROCESS_ATTACH, NULL);
+            callback++;
         }
     }
+    return TRUE;
 }
 
-static void
-PerformBaseRelocation(PMEMORYMODULE module, SIZE_T delta)
+static BOOL
+PerformBaseRelocation(PMEMORYMODULE module, ptrdiff_t delta)
 {
-    DWORD i;
     unsigned char *codeBase = module->codeBase;
+    PIMAGE_BASE_RELOCATION relocation;
 
     PIMAGE_DATA_DIRECTORY directory = GET_HEADER_DICTIONARY(module, IMAGE_DIRECTORY_ENTRY_BASERELOC);
-    if (directory->Size > 0) {
-        PIMAGE_BASE_RELOCATION relocation = (PIMAGE_BASE_RELOCATION) (codeBase + directory->VirtualAddress);
-        for (; relocation->VirtualAddress > 0; ) {
-            unsigned char *dest = codeBase + relocation->VirtualAddress;
-            unsigned short *relInfo = (unsigned short *)((unsigned char *)relocation + IMAGE_SIZEOF_BASE_RELOCATION);
-            for (i=0; i<((relocation->SizeOfBlock-IMAGE_SIZEOF_BASE_RELOCATION) / 2); i++, relInfo++) {
-                DWORD *patchAddrHL;
-#ifdef _WIN64
-                ULONGLONG *patchAddr64;
-#endif
-                int type, offset;
-
-                // the upper 4 bits define the type of relocation
-                type = *relInfo >> 12;
-                // the lower 12 bits define the offset
-                offset = *relInfo & 0xfff;
-
-                switch (type)
-                {
-                case IMAGE_REL_BASED_ABSOLUTE:
-                    // skip relocation
-                    break;
-
-                case IMAGE_REL_BASED_HIGHLOW:
-                    // change complete 32 bit address
-                    patchAddrHL = (DWORD *) (dest + offset);
-                    *patchAddrHL += (DWORD) delta;
-                    break;
-
-#ifdef _WIN64
-                case IMAGE_REL_BASED_DIR64:
-                    patchAddr64 = (ULONGLONG *) (dest + offset);
-                    *patchAddr64 += (ULONGLONG) delta;
-                    break;
-#endif
-
-                default:
-                    //printf("Unknown relocation: %d\n", type);
-                    break;
-                }
-            }
-
-            // advance to next relocation block
-            relocation = (PIMAGE_BASE_RELOCATION) (((char *) relocation) + relocation->SizeOfBlock);
-        }
+    if (directory->Size == 0) {
+        return (delta == 0);
     }
+
+    relocation = (PIMAGE_BASE_RELOCATION) (codeBase + directory->VirtualAddress);
+    for (; relocation->VirtualAddress > 0; ) {
+        DWORD i;
+        unsigned char *dest = codeBase + relocation->VirtualAddress;
+        unsigned short *relInfo = (unsigned short*) OffsetPointer(relocation, IMAGE_SIZEOF_BASE_RELOCATION);
+        for (i=0; i<((relocation->SizeOfBlock-IMAGE_SIZEOF_BASE_RELOCATION) / 2); i++, relInfo++) {
+            // the upper 4 bits define the type of relocation
+            int type = *relInfo >> 12;
+            // the lower 12 bits define the offset
+            int offset = *relInfo & 0xfff;
+
+            switch (type)
+            {
+            case IMAGE_REL_BASED_ABSOLUTE:
+                // skip relocation
+                break;
+
+            case IMAGE_REL_BASED_HIGHLOW:
+                // change complete 32 bit address
+                {
+                    DWORD *patchAddrHL = (DWORD *) (dest + offset);
+                    *patchAddrHL += (DWORD) delta;
+                }
+                break;
+
+#ifdef _WIN64
+            case IMAGE_REL_BASED_DIR64:
+                {
+                    ULONGLONG *patchAddr64 = (ULONGLONG *) (dest + offset);
+                    *patchAddr64 += (ULONGLONG) delta;
+                }
+                break;
+#endif
+
+            default:
+                //printf("Unknown relocation: %d\n", type);
+                break;
+            }
+        }
+
+        // advance to next relocation block
+        relocation = (PIMAGE_BASE_RELOCATION) OffsetPointer(relocation, relocation->SizeOfBlock);
+    }
+    return TRUE;
 }
 
-static int
+static BOOL
 BuildImportTable(PMEMORYMODULE module)
 {
-    int result=1;
     unsigned char *codeBase = module->codeBase;
-    HCUSTOMMODULE *tmp;
+    PIMAGE_IMPORT_DESCRIPTOR importDesc;
+    BOOL result = TRUE;
 
     PIMAGE_DATA_DIRECTORY directory = GET_HEADER_DICTIONARY(module, IMAGE_DIRECTORY_ENTRY_IMPORT);
-    if (directory->Size > 0) {
-        PIMAGE_IMPORT_DESCRIPTOR importDesc = (PIMAGE_IMPORT_DESCRIPTOR) (codeBase + directory->VirtualAddress);
-        for (; !IsBadReadPtr(importDesc, sizeof(IMAGE_IMPORT_DESCRIPTOR)) && importDesc->Name; importDesc++) {
-            POINTER_TYPE *thunkRef;
-            FARPROC *funcRef;
-            HCUSTOMMODULE handle = module->loadLibrary((LPCSTR) (codeBase + importDesc->Name), module->userdata);
-            if (handle == NULL) {
-                SetLastError(ERROR_MOD_NOT_FOUND);
-                result = 0;
-                break;
-            }
+    if (directory->Size == 0) {
+        return TRUE;
+    }
 
-            tmp = (HCUSTOMMODULE *) realloc(module->modules, (module->numModules+1)*(sizeof(HCUSTOMMODULE)));
-            if (tmp == NULL) {
-                module->freeLibrary(handle, module->userdata);
-                SetLastError(ERROR_OUTOFMEMORY);
-                result = 0;
-                break;
-            }
-            module->modules = tmp;
+    importDesc = (PIMAGE_IMPORT_DESCRIPTOR) (codeBase + directory->VirtualAddress);
+    for (; !IsBadReadPtr(importDesc, sizeof(IMAGE_IMPORT_DESCRIPTOR)) && importDesc->Name; importDesc++) {
+        uintptr_t *thunkRef;
+        FARPROC *funcRef;
+        HCUSTOMMODULE *tmp;
+        HCUSTOMMODULE handle = module->loadLibrary((LPCSTR) (codeBase + importDesc->Name), module->userdata);
+        if (handle == NULL) {
+            SetLastError(ERROR_MOD_NOT_FOUND);
+            result = FALSE;
+            break;
+        }
 
-            module->modules[module->numModules++] = handle;
-            if (importDesc->OriginalFirstThunk) {
-                thunkRef = (POINTER_TYPE *) (codeBase + importDesc->OriginalFirstThunk);
-                funcRef = (FARPROC *) (codeBase + importDesc->FirstThunk);
+        tmp = (HCUSTOMMODULE *) realloc(module->modules, (module->numModules+1)*(sizeof(HCUSTOMMODULE)));
+        if (tmp == NULL) {
+            module->freeLibrary(handle, module->userdata);
+            SetLastError(ERROR_OUTOFMEMORY);
+            result = FALSE;
+            break;
+        }
+        module->modules = tmp;
+
+        module->modules[module->numModules++] = handle;
+        if (importDesc->OriginalFirstThunk) {
+            thunkRef = (uintptr_t *) (codeBase + importDesc->OriginalFirstThunk);
+            funcRef = (FARPROC *) (codeBase + importDesc->FirstThunk);
+        } else {
+            // no hint table
+            thunkRef = (uintptr_t *) (codeBase + importDesc->FirstThunk);
+            funcRef = (FARPROC *) (codeBase + importDesc->FirstThunk);
+        }
+        for (; *thunkRef; thunkRef++, funcRef++) {
+            if (IMAGE_SNAP_BY_ORDINAL(*thunkRef)) {
+                *funcRef = module->getProcAddress(handle, (LPCSTR)IMAGE_ORDINAL(*thunkRef), module->userdata);
             } else {
-                // no hint table
-                thunkRef = (POINTER_TYPE *) (codeBase + importDesc->FirstThunk);
-                funcRef = (FARPROC *) (codeBase + importDesc->FirstThunk);
+                PIMAGE_IMPORT_BY_NAME thunkData = (PIMAGE_IMPORT_BY_NAME) (codeBase + (*thunkRef));
+                *funcRef = module->getProcAddress(handle, (LPCSTR)&thunkData->Name, module->userdata);
             }
-            for (; *thunkRef; thunkRef++, funcRef++) {
-                if (IMAGE_SNAP_BY_ORDINAL(*thunkRef)) {
-                    *funcRef = module->getProcAddress(handle, (LPCSTR)IMAGE_ORDINAL(*thunkRef), module->userdata);
-                } else {
-                    PIMAGE_IMPORT_BY_NAME thunkData = (PIMAGE_IMPORT_BY_NAME) (codeBase + (*thunkRef));
-                    *funcRef = module->getProcAddress(handle, (LPCSTR)&thunkData->Name, module->userdata);
-                }
-                if (*funcRef == 0) {
-                    result = 0;
-                    break;
-                }
-            }
-
-            if (!result) {
-                module->freeLibrary(handle, module->userdata);
-                SetLastError(ERROR_PROC_NOT_FOUND);
+            if (*funcRef == 0) {
+                result = FALSE;
                 break;
             }
+        }
+
+        if (!result) {
+            module->freeLibrary(handle, module->userdata);
+            SetLastError(ERROR_PROC_NOT_FOUND);
+            break;
         }
     }
 
     return result;
 }
 
-static HCUSTOMMODULE _LoadLibrary(LPCSTR filename, void *userdata)
+LPVOID MemoryDefaultAlloc(LPVOID address, SIZE_T size, DWORD allocationType, DWORD protect, void* userdata)
 {
-    HMODULE result = LoadLibraryA(filename);
+	UNREFERENCED_PARAMETER(userdata);
+	return VirtualAlloc(address, size, allocationType, protect);
+}
+
+BOOL MemoryDefaultFree(LPVOID lpAddress, SIZE_T dwSize, DWORD dwFreeType, void* userdata)
+{
+	UNREFERENCED_PARAMETER(userdata);
+	return VirtualFree(lpAddress, dwSize, dwFreeType);
+}
+
+HCUSTOMMODULE MemoryDefaultLoadLibrary(LPCSTR filename, void *userdata)
+{
+    HMODULE result;
+    UNREFERENCED_PARAMETER(userdata);
+    result = LoadLibraryA(filename);
     if (result == NULL) {
         return NULL;
     }
@@ -352,43 +524,94 @@ static HCUSTOMMODULE _LoadLibrary(LPCSTR filename, void *userdata)
     return (HCUSTOMMODULE) result;
 }
 
-static FARPROC _GetProcAddress(HCUSTOMMODULE module, LPCSTR name, void *userdata)
+FARPROC MemoryDefaultGetProcAddress(HCUSTOMMODULE module, LPCSTR name, void *userdata)
 {
+    UNREFERENCED_PARAMETER(userdata);
     return (FARPROC) GetProcAddress((HMODULE) module, name);
 }
 
-static void _FreeLibrary(HCUSTOMMODULE module, void *userdata)
+void MemoryDefaultFreeLibrary(HCUSTOMMODULE module, void *userdata)
 {
+    UNREFERENCED_PARAMETER(userdata);
     FreeLibrary((HMODULE) module);
 }
 
-HMEMORYMODULE MemoryLoadLibrary(const void *data)
+HMEMORYMODULE MemoryLoadLibrary(const void *data, size_t size)
 {
-    return MemoryLoadLibraryEx(data, _LoadLibrary, _GetProcAddress, _FreeLibrary, NULL);
+    return MemoryLoadLibraryEx(data, size, MemoryDefaultAlloc, MemoryDefaultFree, MemoryDefaultLoadLibrary, MemoryDefaultGetProcAddress, MemoryDefaultFreeLibrary, NULL);
 }
 
-HMEMORYMODULE MemoryLoadLibraryEx(const void *data,
+HMEMORYMODULE MemoryLoadLibraryEx(const void *data, size_t size,
+    CustomAllocFunc allocMemory,
+    CustomFreeFunc freeMemory,
     CustomLoadLibraryFunc loadLibrary,
     CustomGetProcAddressFunc getProcAddress,
     CustomFreeLibraryFunc freeLibrary,
     void *userdata)
 {
-    PMEMORYMODULE result;
+    PMEMORYMODULE result = NULL;
     PIMAGE_DOS_HEADER dos_header;
     PIMAGE_NT_HEADERS old_header;
     unsigned char *code, *headers;
-    SIZE_T locationDelta;
-    DllEntryProc DllEntry;
-    BOOL successfull;
+    ptrdiff_t locationDelta;
+    SYSTEM_INFO sysInfo;
+    PIMAGE_SECTION_HEADER section;
+    DWORD i;
+    size_t optionalSectionSize;
+    size_t lastSectionEnd = 0;
+    size_t alignedImageSize;
+#ifdef _WIN64
+    POINTER_LIST *blockedMemory = NULL;
+#endif
 
+    if (!CheckSize(size, sizeof(IMAGE_DOS_HEADER))) {
+        return NULL;
+    }
     dos_header = (PIMAGE_DOS_HEADER)data;
     if (dos_header->e_magic != IMAGE_DOS_SIGNATURE) {
         SetLastError(ERROR_BAD_EXE_FORMAT);
         return NULL;
     }
 
+    if (!CheckSize(size, dos_header->e_lfanew + sizeof(IMAGE_NT_HEADERS))) {
+        return NULL;
+    }
     old_header = (PIMAGE_NT_HEADERS)&((const unsigned char *)(data))[dos_header->e_lfanew];
     if (old_header->Signature != IMAGE_NT_SIGNATURE) {
+        SetLastError(ERROR_BAD_EXE_FORMAT);
+        return NULL;
+    }
+
+    if (old_header->FileHeader.Machine != HOST_MACHINE) {
+        SetLastError(ERROR_BAD_EXE_FORMAT);
+        return NULL;
+    }
+
+    if (old_header->OptionalHeader.SectionAlignment & 1) {
+        // Only support section alignments that are a multiple of 2
+        SetLastError(ERROR_BAD_EXE_FORMAT);
+        return NULL;
+    }
+
+    section = IMAGE_FIRST_SECTION(old_header);
+    optionalSectionSize = old_header->OptionalHeader.SectionAlignment;
+    for (i=0; i<old_header->FileHeader.NumberOfSections; i++, section++) {
+        size_t endOfSection;
+        if (section->SizeOfRawData == 0) {
+            // Section without data in the DLL
+            endOfSection = section->VirtualAddress + optionalSectionSize;
+        } else {
+            endOfSection = section->VirtualAddress + section->SizeOfRawData;
+        }
+
+        if (endOfSection > lastSectionEnd) {
+            lastSectionEnd = endOfSection;
+        }
+    }
+
+    GetNativeSystemInfo(&sysInfo);
+    alignedImageSize = AlignValueUp(old_header->OptionalHeader.SizeOfImage, sysInfo.dwPageSize);
+    if (alignedImageSize != AlignValueUp(lastSectionEnd, sysInfo.dwPageSize)) {
         SetLastError(ERROR_BAD_EXE_FORMAT);
         return NULL;
     }
@@ -396,62 +619,105 @@ HMEMORYMODULE MemoryLoadLibraryEx(const void *data,
     // reserve memory for image of library
     // XXX: is it correct to commit the complete memory region at once?
     //      calling DllEntry raises an exception if we don't...
-    code = (unsigned char *)VirtualAlloc((LPVOID)(old_header->OptionalHeader.ImageBase),
-        old_header->OptionalHeader.SizeOfImage,
+    code = (unsigned char *)allocMemory((LPVOID)(old_header->OptionalHeader.ImageBase),
+        alignedImageSize,
         MEM_RESERVE | MEM_COMMIT,
-        PAGE_READWRITE);
+        PAGE_READWRITE,
+        userdata);
 
     if (code == NULL) {
         // try to allocate memory at arbitrary position
-        code = (unsigned char *)VirtualAlloc(NULL,
-            old_header->OptionalHeader.SizeOfImage,
+        code = (unsigned char *)allocMemory(NULL,
+            alignedImageSize,
             MEM_RESERVE | MEM_COMMIT,
-            PAGE_READWRITE);
+            PAGE_READWRITE,
+            userdata);
         if (code == NULL) {
             SetLastError(ERROR_OUTOFMEMORY);
             return NULL;
         }
     }
 
-    result = (PMEMORYMODULE)HeapAlloc(GetProcessHeap(), 0, sizeof(MEMORYMODULE));
+#ifdef _WIN64
+    // Memory block may not span 4 GB boundaries.
+    while ((((uintptr_t) code) >> 32) < (((uintptr_t) (code + alignedImageSize)) >> 32)) {
+        POINTER_LIST *node = (POINTER_LIST*) malloc(sizeof(POINTER_LIST));
+        if (!node) {
+            freeMemory(code, 0, MEM_RELEASE, userdata);
+            FreePointerList(blockedMemory, freeMemory, userdata);
+            SetLastError(ERROR_OUTOFMEMORY);
+            return NULL;
+        }
+
+        node->next = blockedMemory;
+        node->address = code;
+        blockedMemory = node;
+
+        code = (unsigned char *)allocMemory(NULL,
+            alignedImageSize,
+            MEM_RESERVE | MEM_COMMIT,
+            PAGE_READWRITE,
+            userdata);
+        if (code == NULL) {
+            FreePointerList(blockedMemory, freeMemory, userdata);
+            SetLastError(ERROR_OUTOFMEMORY);
+            return NULL;
+        }
+    }
+#endif
+
+    result = (PMEMORYMODULE)HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, sizeof(MEMORYMODULE));
     if (result == NULL) {
+        freeMemory(code, 0, MEM_RELEASE, userdata);
+#ifdef _WIN64
+        FreePointerList(blockedMemory, freeMemory, userdata);
+#endif
         SetLastError(ERROR_OUTOFMEMORY);
-        VirtualFree(code, 0, MEM_RELEASE);
         return NULL;
     }
 
     result->codeBase = code;
-    result->numModules = 0;
-    result->modules = NULL;
-    result->initialized = 0;
+    result->isDLL = (old_header->FileHeader.Characteristics & IMAGE_FILE_DLL) != 0;
+    result->alloc = allocMemory;
+    result->free = freeMemory;
     result->loadLibrary = loadLibrary;
     result->getProcAddress = getProcAddress;
     result->freeLibrary = freeLibrary;
     result->userdata = userdata;
-#ifdef USE_BINARY_SEARCH
-    result->name_table = NULL;
+    result->pageSize = sysInfo.dwPageSize;
+#ifdef _WIN64
+    result->blockedMemory = blockedMemory;
 #endif
 
+    if (!CheckSize(size, old_header->OptionalHeader.SizeOfHeaders)) {
+        goto error;
+    }
+
     // commit memory for headers
-    headers = (unsigned char *)VirtualAlloc(code,
+    headers = (unsigned char *)allocMemory(code,
         old_header->OptionalHeader.SizeOfHeaders,
         MEM_COMMIT,
-        PAGE_READWRITE);
+        PAGE_READWRITE,
+        userdata);
 
     // copy PE header to code
     memcpy(headers, dos_header, old_header->OptionalHeader.SizeOfHeaders);
     result->headers = (PIMAGE_NT_HEADERS)&((const unsigned char *)(headers))[dos_header->e_lfanew];
 
     // update position
-    result->headers->OptionalHeader.ImageBase = (POINTER_TYPE)code;
+    result->headers->OptionalHeader.ImageBase = (uintptr_t)code;
 
     // copy sections from DLL file block to new memory location
-    CopySections(data, old_header, result);
+    if (!CopySections((const unsigned char *) data, size, old_header, result)) {
+        goto error;
+    }
 
     // adjust base address of imported data
-    locationDelta = (SIZE_T)(code - old_header->OptionalHeader.ImageBase);
+    locationDelta = (ptrdiff_t)(result->headers->OptionalHeader.ImageBase - old_header->OptionalHeader.ImageBase);
     if (locationDelta != 0) {
-        PerformBaseRelocation(result, locationDelta);
+        result->isRelocated = PerformBaseRelocation(result, locationDelta);
+    } else {
+        result->isRelocated = TRUE;
     }
 
     // load required dlls and adjust function table of imports
@@ -461,21 +727,31 @@ HMEMORYMODULE MemoryLoadLibraryEx(const void *data,
 
     // mark memory pages depending on section headers and release
     // sections that are marked as "discardable"
-    FinalizeSections(result);
+    if (!FinalizeSections(result)) {
+        goto error;
+    }
 
     // TLS callbacks are executed BEFORE the main loading
-    ExecuteTLS(result);
+    if (!ExecuteTLS(result)) {
+        goto error;
+    }
 
     // get entry point of loaded library
     if (result->headers->OptionalHeader.AddressOfEntryPoint != 0) {
-        DllEntry = (DllEntryProc) (code + result->headers->OptionalHeader.AddressOfEntryPoint);
-        // notify library about attaching to process
-        successfull = (*DllEntry)((HINSTANCE)code, DLL_PROCESS_ATTACH, 0);
-        if (!successfull) {
-            SetLastError(ERROR_DLL_INIT_FAILED);
-            goto error;
+        if (result->isDLL) {
+            DllEntryProc DllEntry = (DllEntryProc)(LPVOID)(code + result->headers->OptionalHeader.AddressOfEntryPoint);
+            // notify library about attaching to process
+            BOOL successfull = (*DllEntry)((HINSTANCE)code, DLL_PROCESS_ATTACH, 0);
+            if (!successfull) {
+                SetLastError(ERROR_DLL_INIT_FAILED);
+                goto error;
+            }
+            result->initialized = TRUE;
+        } else {
+            result->exeEntry = (ExeEntryProc)(LPVOID)(code + result->headers->OptionalHeader.AddressOfEntryPoint);
         }
-        result->initialized = 1;
+    } else {
+        result->exeEntry = NULL;
     }
 
     return (HMEMORYMODULE)result;
@@ -486,26 +762,27 @@ error:
     return NULL;
 }
 
-#ifdef USE_BINARY_SEARCH
-int _compare(const struct NAME_TABLE *p1, const struct NAME_TABLE *p2)
+static int _compare(const void *a, const void *b)
 {
-    return _stricmp(p1->name, p2->name);
+    const struct ExportNameEntry *p1 = (const struct ExportNameEntry*) a;
+    const struct ExportNameEntry *p2 = (const struct ExportNameEntry*) b;
+    return strcmp(p1->name, p2->name);
 }
 
-int _find(LPCSTR *name, const struct NAME_TABLE *p)
+static int _find(const void *a, const void *b)
 {
-    return _stricmp(*name, p->name);
+    LPCSTR *name = (LPCSTR *) a;
+    const struct ExportNameEntry *p = (const struct ExportNameEntry*) b;
+    return strcmp(*name, p->name);
 }
-#endif
 
-FARPROC MemoryGetProcAddress(HMEMORYMODULE module, LPCSTR name)
+FARPROC MemoryGetProcAddress(HMEMORYMODULE mod, LPCSTR name)
 {
-    unsigned char *codeBase = ((PMEMORYMODULE)module)->codeBase;
-    int idx=-1;
-    DWORD i, *nameRef;
-    WORD *ordinal;
+    PMEMORYMODULE module = (PMEMORYMODULE)mod;
+    unsigned char *codeBase = module->codeBase;
+    DWORD idx = 0;
     PIMAGE_EXPORT_DIRECTORY exports;
-    PIMAGE_DATA_DIRECTORY directory = GET_HEADER_DICTIONARY((PMEMORYMODULE)module, IMAGE_DIRECTORY_ENTRY_EXPORT);
+    PIMAGE_DATA_DIRECTORY directory = GET_HEADER_DICTIONARY(module, IMAGE_DIRECTORY_ENTRY_EXPORT);
     if (directory->Size == 0) {
         // no export table found
         SetLastError(ERROR_PROC_NOT_FOUND);
@@ -519,112 +796,110 @@ FARPROC MemoryGetProcAddress(HMEMORYMODULE module, LPCSTR name)
         return NULL;
     }
 
-#ifdef USE_BINARY_SEARCH
+    if (HIWORD(name) == 0) {
+        // load function by ordinal value
+        if (LOWORD(name) < exports->Base) {
+            SetLastError(ERROR_PROC_NOT_FOUND);
+            return NULL;
+        }
 
-    // build name table and sort it by names
-    if (((PMEMORYMODULE)module)->name_table == NULL) {
-	struct NAME_TABLE *entry = (struct NAME_TABLE*)malloc(exports->NumberOfNames
-							      * sizeof(struct NAME_TABLE));
-	((PMEMORYMODULE)module)->name_table = entry;
-	if (entry == NULL) {
-	    ((PMEMORYMODULE)module)->numEntries = 0;
-	    SetLastError(ERROR_OUTOFMEMORY);
-	    return NULL;
-	}
-	((PMEMORYMODULE)module)->numEntries = exports->NumberOfNames;
-
-	nameRef = (DWORD *) (codeBase + exports->AddressOfNames);
-	ordinal = (WORD *) (codeBase + exports->AddressOfNameOrdinals);
-	for (i=0; i<exports->NumberOfNames; i++, nameRef++, ordinal++) {
-	    entry->name = (const char *) (codeBase + (*nameRef));
-	    entry->idx = *ordinal;
-	    entry++;
-	}
-	entry = ((PMEMORYMODULE)module)->name_table;
-	qsort(entry, exports->NumberOfNames, sizeof(struct NAME_TABLE), _compare);
-    }
-
-    if (!IS_INTRESOURCE(name)) {
-	// search function name in list of exported names with binary search
-	if (((PMEMORYMODULE)module)->name_table) {
-	    struct NAME_TABLE *found;
-	    found = bsearch(&name,
-			    ((PMEMORYMODULE)module)->name_table,
-			    exports->NumberOfNames,
-			    sizeof(struct NAME_TABLE), _find);
-	    if (found)
-		idx = found->idx;
-	}
-    } else
-	idx = (int)name;
-#else
-    if (!IS_INTRESOURCE(name)) {
-	// search function name in list of exported names
-	nameRef = (DWORD *) (codeBase + exports->AddressOfNames);
-	ordinal = (WORD *) (codeBase + exports->AddressOfNameOrdinals);
-	for (i=0; i<exports->NumberOfNames; i++, nameRef++, ordinal++) {
-	    if (_stricmp(name, (const char *) (codeBase + (*nameRef))) == 0) {
-		idx = *ordinal;
-		break;
-	    }
-	}
-    } else
-	idx = (int)name;
-#endif
-
-    if (idx == -1) {
-        // exported symbol not found
+        idx = LOWORD(name) - exports->Base;
+    } else if (!exports->NumberOfNames) {
         SetLastError(ERROR_PROC_NOT_FOUND);
         return NULL;
+    } else {
+        const struct ExportNameEntry *found;
+
+        // Lazily build name table and sort it by names
+        if (!module->nameExportsTable) {
+            DWORD i;
+            DWORD *nameRef = (DWORD *) (codeBase + exports->AddressOfNames);
+            WORD *ordinal = (WORD *) (codeBase + exports->AddressOfNameOrdinals);
+            struct ExportNameEntry *entry = (struct ExportNameEntry*) malloc(exports->NumberOfNames * sizeof(struct ExportNameEntry));
+            module->nameExportsTable = entry;
+            if (!entry) {
+                SetLastError(ERROR_OUTOFMEMORY);
+                return NULL;
+            }
+            for (i=0; i<exports->NumberOfNames; i++, nameRef++, ordinal++, entry++) {
+                entry->name = (const char *) (codeBase + (*nameRef));
+                entry->idx = *ordinal;
+            }
+            qsort(module->nameExportsTable,
+                    exports->NumberOfNames,
+                    sizeof(struct ExportNameEntry), _compare);
+        }
+
+        // search function name in list of exported names with binary search
+        found = (const struct ExportNameEntry*) bsearch(&name,
+                module->nameExportsTable,
+                exports->NumberOfNames,
+                sizeof(struct ExportNameEntry), _find);
+        if (!found) {
+            // exported symbol not found
+            SetLastError(ERROR_PROC_NOT_FOUND);
+            return NULL;
+        }
+
+        idx = found->idx;
     }
 
-    if ((DWORD)idx > exports->NumberOfFunctions) {
+    if (idx > exports->NumberOfFunctions) {
         // name <-> ordinal number don't match
         SetLastError(ERROR_PROC_NOT_FOUND);
         return NULL;
     }
 
     // AddressOfFunctions contains the RVAs to the "real" functions
-    return (FARPROC) (codeBase + (*(DWORD *) (codeBase + exports->AddressOfFunctions + (idx*4))));
+    return (FARPROC)(LPVOID)(codeBase + (*(DWORD *) (codeBase + exports->AddressOfFunctions + (idx*4))));
 }
 
 void MemoryFreeLibrary(HMEMORYMODULE mod)
 {
-    int i;
     PMEMORYMODULE module = (PMEMORYMODULE)mod;
 
-    if (module != NULL) {
-        if (module->initialized != 0) {
-            // notify library about detaching from process
-            DllEntryProc DllEntry = (DllEntryProc) (module->codeBase + module->headers->OptionalHeader.AddressOfEntryPoint);
-            (*DllEntry)((HINSTANCE)module->codeBase, DLL_PROCESS_DETACH, 0);
-            module->initialized = 0;
-        }
-
-#ifdef USE_BINARY_SEARCH
-	if (module->name_table != NULL) {
-	    free(module->name_table);
-	}
-#endif
-
-        if (module->modules != NULL) {
-            // free previously opened libraries
-            for (i=0; i<module->numModules; i++) {
-                if (module->modules[i] != NULL) {
-                    module->freeLibrary(module->modules[i], module->userdata);
-                }
-            }
-
-            free(module->modules);
-        }
-
-        if (module->codeBase != NULL) {
-            // release memory of library
-            VirtualFree(module->codeBase, 0, MEM_RELEASE);
-        }
-
-        HeapFree(GetProcessHeap(), 0, module);
+    if (module == NULL) {
+        return;
     }
+    if (module->initialized) {
+        // notify library about detaching from process
+        DllEntryProc DllEntry = (DllEntryProc)(LPVOID)(module->codeBase + module->headers->OptionalHeader.AddressOfEntryPoint);
+        (*DllEntry)((HINSTANCE)module->codeBase, DLL_PROCESS_DETACH, 0);
+    }
+
+    free(module->nameExportsTable);
+    if (module->modules != NULL) {
+        // free previously opened libraries
+        int i;
+        for (i=0; i<module->numModules; i++) {
+            if (module->modules[i] != NULL) {
+                module->freeLibrary(module->modules[i], module->userdata);
+            }
+        }
+
+        free(module->modules);
+    }
+
+    if (module->codeBase != NULL) {
+        // release memory of library
+        module->free(module->codeBase, 0, MEM_RELEASE, module->userdata);
+    }
+
+#ifdef _WIN64
+    FreePointerList(module->blockedMemory, module->free, module->userdata);
+#endif
+    HeapFree(GetProcessHeap(), 0, module);
+}
+
+int MemoryCallEntryPoint(HMEMORYMODULE mod)
+{
+    PMEMORYMODULE module = (PMEMORYMODULE)mod;
+
+    if (module == NULL || module->isDLL || module->exeEntry == NULL || !module->isRelocated) {
+        return -1;
+    }
+
+    return module->exeEntry();
 }
 
 #define DEFAULT_LANGUAGE        MAKELANGID(LANG_NEUTRAL, SUBLANG_NEUTRAL)
@@ -648,11 +923,7 @@ static PIMAGE_RESOURCE_DIRECTORY_ENTRY _MemorySearchResourceEntry(
     if (!IS_INTRESOURCE(key) && key[0] == TEXT('#')) {
         // special case: resource id given as string
         TCHAR *endpos = NULL;
-#if defined(UNICODE)
-        long int tmpkey = (WORD) wcstol((TCHAR *) &key[1], &endpos, 10);
-#else
-        long int tmpkey = (WORD) strtol((TCHAR *) &key[1], &endpos, 10);
-#endif
+        long int tmpkey = (WORD) _tcstol((TCHAR *) &key[1], &endpos, 10);
         if (tmpkey <= 0xffff && lstrlen(endpos) == 0) {
             key = MAKEINTRESOURCE(tmpkey);
         }
@@ -662,7 +933,7 @@ static PIMAGE_RESOURCE_DIRECTORY_ENTRY _MemorySearchResourceEntry(
     // followed by an ordered list of id entries - we can do
     // a binary search to find faster...
     if (IS_INTRESOURCE(key)) {
-        WORD check = (WORD) (POINTER_TYPE) key;
+        WORD check = (WORD) (uintptr_t) key;
         start = resources->NumberOfNamedEntries;
         end = start + resources->NumberOfIdEntries;
 
@@ -680,32 +951,49 @@ static PIMAGE_RESOURCE_DIRECTORY_ENTRY _MemorySearchResourceEntry(
             }
         }
     } else {
-#if !defined(UNICODE)
-        char *searchKey = NULL;
-        int searchKeyLength = 0;
+        LPCWSTR searchKey;
+        size_t searchKeyLen = _tcslen(key);
+#if defined(UNICODE)
+        searchKey = key;
+#else
+        // Resource names are always stored using 16bit characters, need to
+        // convert string we search for.
+#define MAX_LOCAL_KEY_LENGTH 2048
+        // In most cases resource names are short, so optimize for that by
+        // using a pre-allocated array.
+        wchar_t _searchKeySpace[MAX_LOCAL_KEY_LENGTH+1];
+        LPWSTR _searchKey;
+        if (searchKeyLen > MAX_LOCAL_KEY_LENGTH) {
+            size_t _searchKeySize = (searchKeyLen + 1) * sizeof(wchar_t);
+            _searchKey = (LPWSTR) malloc(_searchKeySize);
+            if (_searchKey == NULL) {
+                SetLastError(ERROR_OUTOFMEMORY);
+                return NULL;
+            }
+        } else {
+            _searchKey = &_searchKeySpace[0];
+        }
+
+        mbstowcs(_searchKey, key, searchKeyLen);
+        _searchKey[searchKeyLen] = 0;
+        searchKey = _searchKey;
 #endif
         start = 0;
-        end = resources->NumberOfIdEntries;
+        end = resources->NumberOfNamedEntries;
         while (end > start) {
-            // resource names are always stored using 16bit characters
             int cmp;
-			PIMAGE_RESOURCE_DIR_STRING_U resourceString;
+            PIMAGE_RESOURCE_DIR_STRING_U resourceString;
             middle = (start + end) >> 1;
-            resourceString = (PIMAGE_RESOURCE_DIR_STRING_U) (((char *) root) + (entries[middle].Name & 0x7FFFFFFF));
-#if !defined(UNICODE)
-            if (searchKey == NULL || searchKeyLength < resourceString->Length) {
-                void *tmp = realloc(searchKey, resourceString->Length);
-                if (tmp == NULL) {
-                    break;
+            resourceString = (PIMAGE_RESOURCE_DIR_STRING_U) OffsetPointer(root, entries[middle].Name & 0x7FFFFFFF);
+            cmp = _wcsnicmp(searchKey, resourceString->NameString, resourceString->Length);
+            if (cmp == 0) {
+                // Handle partial match
+                if (searchKeyLen > resourceString->Length) {
+                    cmp = 1;
+                } else if (searchKeyLen < resourceString->Length) {
+                    cmp = -1;
                 }
-
-                searchKey = (char *) tmp;
             }
-            wcstombs(searchKey, resourceString->NameString, resourceString->Length);
-            cmp = strncmp(key, searchKey, resourceString->Length);
-#else
-            cmp = wcsncmp(key, resourceString->NameString, resourceString->Length);
-#endif
             if (cmp < 0) {
                 end = (middle != end ? middle : middle-1);
             } else if (cmp > 0) {
@@ -716,10 +1004,12 @@ static PIMAGE_RESOURCE_DIRECTORY_ENTRY _MemorySearchResourceEntry(
             }
         }
 #if !defined(UNICODE)
-        free(searchKey);
+        if (searchKeyLen > MAX_LOCAL_KEY_LENGTH) {
+            free(_searchKey);
+        }
+#undef MAX_LOCAL_KEY_LENGTH
 #endif
     }
-
 
     return result;
 }
@@ -764,7 +1054,7 @@ HMEMORYRSRC MemoryFindResourceEx(HMEMORYMODULE module, LPCTSTR name, LPCTSTR typ
     }
 
     nameResources = (PIMAGE_RESOURCE_DIRECTORY) (codeBase + directory->VirtualAddress + (foundName->OffsetToData & 0x7fffffff));
-    foundLanguage = _MemorySearchResourceEntry(rootResources, nameResources, (LPCTSTR) (POINTER_TYPE) language);
+    foundLanguage = _MemorySearchResourceEntry(rootResources, nameResources, (LPCTSTR) (uintptr_t) language);
     if (foundLanguage == NULL) {
         // requested language not found, use first available
         if (nameResources->NumberOfIdEntries == 0) {
@@ -780,7 +1070,12 @@ HMEMORYRSRC MemoryFindResourceEx(HMEMORYMODULE module, LPCTSTR name, LPCTSTR typ
 
 DWORD MemorySizeofResource(HMEMORYMODULE module, HMEMORYRSRC resource)
 {
-    PIMAGE_RESOURCE_DATA_ENTRY entry = (PIMAGE_RESOURCE_DATA_ENTRY) resource;
+    PIMAGE_RESOURCE_DATA_ENTRY entry;
+    UNREFERENCED_PARAMETER(module);
+    entry = (PIMAGE_RESOURCE_DATA_ENTRY) resource;
+    if (entry == NULL) {
+        return 0;
+    }
 
     return entry->Size;
 }
@@ -789,6 +1084,9 @@ LPVOID MemoryLoadResource(HMEMORYMODULE module, HMEMORYRSRC resource)
 {
     unsigned char *codeBase = ((PMEMORYMODULE) module)->codeBase;
     PIMAGE_RESOURCE_DATA_ENTRY entry = (PIMAGE_RESOURCE_DATA_ENTRY) resource;
+    if (entry == NULL) {
+        return NULL;
+    }
 
     return codeBase + entry->OffsetToData;
 }
@@ -802,9 +1100,9 @@ MemoryLoadString(HMEMORYMODULE module, UINT id, LPTSTR buffer, int maxsize)
 int
 MemoryLoadStringEx(HMEMORYMODULE module, UINT id, LPTSTR buffer, int maxsize, WORD language)
 {
-	HMEMORYRSRC resource;
-	PIMAGE_RESOURCE_DIR_STRING_U data;
-	DWORD size;
+    HMEMORYRSRC resource;
+    PIMAGE_RESOURCE_DIR_STRING_U data;
+    DWORD size;
     if (maxsize == 0) {
         return 0;
     }
@@ -815,10 +1113,10 @@ MemoryLoadStringEx(HMEMORYMODULE module, UINT id, LPTSTR buffer, int maxsize, WO
         return 0;
     }
 
-    data = MemoryLoadResource(module, resource);
+    data = (PIMAGE_RESOURCE_DIR_STRING_U) MemoryLoadResource(module, resource);
     id = id & 0x0f;
     while (id--) {
-        data = (PIMAGE_RESOURCE_DIR_STRING_U) (((char *) data) + (data->Length + 1) * sizeof(WCHAR));
+        data = (PIMAGE_RESOURCE_DIR_STRING_U) OffsetPointer(data, (data->Length + 1) * sizeof(WCHAR));
     }
     if (data->Length == 0) {
         SetLastError(ERROR_RESOURCE_NAME_NOT_FOUND);
@@ -839,3 +1137,66 @@ MemoryLoadStringEx(HMEMORYMODULE module, UINT id, LPTSTR buffer, int maxsize, WO
 #endif
     return size;
 }
+
+#ifdef TESTSUITE
+#include <stdio.h>
+
+#ifndef PRIxPTR
+#ifdef _WIN64
+#define PRIxPTR "I64x"
+#else
+#define PRIxPTR "x"
+#endif
+#endif
+
+static const uintptr_t AlignValueDownTests[][3] = {
+    {16, 16, 16},
+    {17, 16, 16},
+    {32, 16, 32},
+    {33, 16, 32},
+#ifdef _WIN64
+    {0x12345678abcd1000, 0x1000, 0x12345678abcd1000},
+    {0x12345678abcd101f, 0x1000, 0x12345678abcd1000},
+#endif
+    {0, 0, 0},
+};
+
+static const uintptr_t AlignValueUpTests[][3] = {
+    {16, 16, 16},
+    {17, 16, 32},
+    {32, 16, 32},
+    {33, 16, 48},
+#ifdef _WIN64
+    {0x12345678abcd1000, 0x1000, 0x12345678abcd1000},
+    {0x12345678abcd101f, 0x1000, 0x12345678abcd2000},
+#endif
+    {0, 0, 0},
+};
+
+BOOL MemoryModuleTestsuite() {
+    BOOL success = TRUE;
+    size_t idx;
+    for (idx = 0; AlignValueDownTests[idx][0]; ++idx) {
+        const uintptr_t* tests = AlignValueDownTests[idx];
+        uintptr_t value = AlignValueDown(tests[0], tests[1]);
+        if (value != tests[2]) {
+            printf("AlignValueDown failed for 0x%" PRIxPTR "/0x%" PRIxPTR ": expected 0x%" PRIxPTR ", got 0x%" PRIxPTR "\n",
+                tests[0], tests[1], tests[2], value);
+            success = FALSE;
+        }
+    }
+    for (idx = 0; AlignValueDownTests[idx][0]; ++idx) {
+        const uintptr_t* tests = AlignValueUpTests[idx];
+        uintptr_t value = AlignValueUp(tests[0], tests[1]);
+        if (value != tests[2]) {
+            printf("AlignValueUp failed for 0x%" PRIxPTR "/0x%" PRIxPTR ": expected 0x%" PRIxPTR ", got 0x%" PRIxPTR "\n",
+                tests[0], tests[1], tests[2], value);
+            success = FALSE;
+        }
+    }
+    if (success) {
+        printf("OK\n");
+    }
+    return success;
+}
+#endif

--- a/source/MemoryModule.h
+++ b/source/MemoryModule.h
@@ -1,8 +1,8 @@
 /*
  * Memory DLL loading code
- * Version 0.0.3
+ * Version 0.0.4
  *
- * Copyright (c) 2004-2013 by Joachim Bauch / mail@joachim-bauch.de
+ * Copyright (c) 2004-2015 by Joachim Bauch / mail@joachim-bauch.de
  * http://www.joachim-bauch.de
  *
  * The contents of this file are subject to the Mozilla Public License Version
@@ -19,7 +19,7 @@
  *
  * The Initial Developer of the Original Code is Joachim Bauch.
  *
- * Portions created by Joachim Bauch are Copyright (C) 2004-2013
+ * Portions created by Joachim Bauch are Copyright (C) 2004-2015
  * Joachim Bauch. All Rights Reserved.
  *
  */
@@ -39,38 +39,57 @@ typedef void *HCUSTOMMODULE;
 extern "C" {
 #endif
 
+typedef LPVOID (*CustomAllocFunc)(LPVOID, SIZE_T, DWORD, DWORD, void*);
+typedef BOOL (*CustomFreeFunc)(LPVOID, SIZE_T, DWORD, void*);
 typedef HCUSTOMMODULE (*CustomLoadLibraryFunc)(LPCSTR, void *);
 typedef FARPROC (*CustomGetProcAddressFunc)(HCUSTOMMODULE, LPCSTR, void *);
 typedef void (*CustomFreeLibraryFunc)(HCUSTOMMODULE, void *);
 
 /**
- * Load DLL from memory location.
+ * Load EXE/DLL from memory location with the given size.
  *
  * All dependencies are resolved using default LoadLibrary/GetProcAddress
  * calls through the Windows API.
  */
-HMEMORYMODULE MemoryLoadLibrary(const void *);
+HMEMORYMODULE MemoryLoadLibrary(const void *, size_t);
 
 /**
- * Load DLL from memory location using custom dependency resolvers.
+ * Load EXE/DLL from memory location with the given size using custom dependency
+ * resolvers.
  *
  * Dependencies will be resolved using passed callback methods.
  */
-HMEMORYMODULE MemoryLoadLibraryEx(const void *,
+HMEMORYMODULE MemoryLoadLibraryEx(const void *, size_t,
+    CustomAllocFunc,
+    CustomFreeFunc,
     CustomLoadLibraryFunc,
     CustomGetProcAddressFunc,
     CustomFreeLibraryFunc,
     void *);
 
 /**
- * Get address of exported method.
+ * Get address of exported method. Supports loading both by name and by
+ * ordinal value.
  */
 FARPROC MemoryGetProcAddress(HMEMORYMODULE, LPCSTR);
 
 /**
- * Free previously loaded DLL.
+ * Free previously loaded EXE/DLL.
  */
 void MemoryFreeLibrary(HMEMORYMODULE);
+
+/**
+ * Execute entry point (EXE only). The entry point can only be executed
+ * if the EXE has been loaded to the correct base address or it could
+ * be relocated (i.e. relocation information have not been stripped by
+ * the linker).
+ *
+ * Important: calling this function will not return, i.e. once the loaded
+ * EXE finished running, the process will terminate.
+ *
+ * Returns a negative value if the entry point could not be executed.
+ */
+int MemoryCallEntryPoint(HMEMORYMODULE);
 
 /**
  * Find the location of a resource with the specified type and name.
@@ -101,6 +120,46 @@ int MemoryLoadString(HMEMORYMODULE, UINT, LPTSTR, int);
  * Load a string resource with a given language.
  */
 int MemoryLoadStringEx(HMEMORYMODULE, UINT, LPTSTR, int, WORD);
+
+/**
+* Default implementation of CustomAllocFunc that calls VirtualAlloc
+* internally to allocate memory for a library
+*
+* This is the default as used by MemoryLoadLibrary.
+*/
+LPVOID MemoryDefaultAlloc(LPVOID, SIZE_T, DWORD, DWORD, void *);
+
+/**
+* Default implementation of CustomFreeFunc that calls VirtualFree
+* internally to free the memory used by a library
+*
+* This is the default as used by MemoryLoadLibrary.
+*/
+BOOL MemoryDefaultFree(LPVOID, SIZE_T, DWORD, void *);
+
+/**
+ * Default implementation of CustomLoadLibraryFunc that calls LoadLibraryA
+ * internally to load an additional libary.
+ *
+ * This is the default as used by MemoryLoadLibrary.
+ */
+HCUSTOMMODULE MemoryDefaultLoadLibrary(LPCSTR, void *);
+
+/**
+ * Default implementation of CustomGetProcAddressFunc that calls GetProcAddress
+ * internally to get the address of an exported function.
+ *
+ * This is the default as used by MemoryLoadLibrary.
+ */
+FARPROC MemoryDefaultGetProcAddress(HCUSTOMMODULE, LPCSTR, void *);
+
+/**
+ * Default implementation of CustomFreeLibraryFunc that calls FreeLibrary
+ * internally to release an additional libary.
+ *
+ * This is the default as used by MemoryLoadLibrary.
+ */
+void MemoryDefaultFreeLibrary(HCUSTOMMODULE, void *);
 
 #ifdef __cplusplus
 }

--- a/source/MyLoadLibrary.c
+++ b/source/MyLoadLibrary.c
@@ -164,9 +164,10 @@ static HCUSTOMMODULE _LoadLibrary(LPCSTR filename, void *userdata)
 //		PyObject *res = PyObject_CallFunction(findproc, "s", filename);
 		PyObject *res = CallFindproc(findproc, filename);
 		if (res && PyBytes_AsString(res)) {
-			result = MemoryLoadLibraryEx(PyBytes_AsString(res),
-						     _LoadLibrary, _GetProcAddress, _FreeLibrary,
-						     userdata);
+			result = MemoryLoadLibraryEx(PyBytes_AsString(res), PyBytes_GET_SIZE(res),
+				MemoryDefaultAlloc, MemoryDefaultFree,
+				_LoadLibrary, _GetProcAddress, _FreeLibrary,
+				userdata);
 			Py_DECREF(res);
 			if (result) {
 				lib = _AddMemoryModule(filename, result);
@@ -203,14 +204,15 @@ HMODULE MyGetModuleHandle(LPCSTR name)
 	//return GetModuleHandle(name);
 }
 
-HMODULE MyLoadLibrary(LPCSTR name, void *bytes, void *userdata)
+HMODULE MyLoadLibrary(LPCSTR name, void *bytes, size_t size, void *userdata)
 {
 	if (userdata) {
 		HCUSTOMMODULE mod = _LoadLibrary(name, userdata);
 		if (mod)
 			return mod;
 	} else if (bytes) {
-		HCUSTOMMODULE mod = MemoryLoadLibraryEx(bytes,
+		HCUSTOMMODULE mod = MemoryLoadLibraryEx(bytes, size,
+							MemoryDefaultAlloc, MemoryDefaultFree,
 							_LoadLibrary,
 							_GetProcAddress,
 							_FreeLibrary,

--- a/source/MyLoadLibrary.h
+++ b/source/MyLoadLibrary.h
@@ -1,7 +1,7 @@
 #ifndef GENERALLOADLIBRARY_H
 #define GENERALLOADLIBRARY_H
 
-HMODULE MyLoadLibrary(LPCSTR, void *, void *);
+HMODULE MyLoadLibrary(LPCSTR, void *, size_t, void *);
 
 HMODULE MyGetModuleHandle(LPCSTR);
 

--- a/source/_memimporter.c
+++ b/source/_memimporter.c
@@ -182,7 +182,7 @@ import_module(PyObject *self, PyObject *args)
 	 * numpy is such an example).
 	 */
 	res = SetDllDirectoryW(dirname); // Add a directory to the search path
-	hmem = MyLoadLibrary(pathname, NULL, findproc);
+	hmem = MyLoadLibrary(pathname, NULL, 0, findproc);
 	if (res)
 		SetDllDirectory(NULL); // restore the default dll directory search path
 	_My_DeactivateActCtx(cookie);

--- a/source/start.c
+++ b/source/start.c
@@ -289,7 +289,7 @@ HMODULE load_pythondll(void)
 		hgbl = LoadResource(hmod, hrsrc);
 		size = SizeofResource(hmod, hrsrc);
 		ptr = LockResource(hgbl);
-		hmod_pydll = MyLoadLibrary(PYTHONDLL, ptr, NULL);
+		hmod_pydll = MyLoadLibrary(PYTHONDLL, ptr, size, NULL);
 	} else
 		/*
 		  XXX We should probably call LoadLibraryEx with


### PR DESCRIPTION
Hello.

Current py2exe uses old MemoryModule. (version 0.0.3) 
This PR updates MemoryModule with the lastest version from https://github.com/fancycode/MemoryModule/commit/5f83e41c to improve stability and performance of _memimport module.
