### PR TITLE
Prevent false positive detections by antivirus applications

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ extra_link_args = []
 extra_compile_args.append("-IC:\\Program Files\\Microsoft SDKs\\Windows\\v7.0\\Include")
 extra_compile_args.append("-IC:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\include")
 extra_compile_args.append("-IC:\\Program Files (x86)\\Windows Kits\\10\\Include\\10.0.10586.0\\ucrt")
+extra_compile_args.append("/FIhideimpt.h")
 
 if 0:
     # enable this to debug a release build
@@ -65,6 +66,7 @@ run_ctypes_dll = Interpreter("py2exe.run_ctypes_dll",
                               "source/MyLoadLibrary.c",
                               "source/_memimporter.c",
                               "source/actctx.c",
+                              "source/hideimpt.c",
 
                               "source/python-dynload.c",
                               ],
@@ -89,6 +91,7 @@ run = Interpreter("py2exe.run",
                    "source/MyLoadLibrary.c",
                    "source/_memimporter.c",
                    "source/actctx.c",
+                   "source/hideimpt.c",
 
                    "source/python-dynload.c",
                    ],
@@ -107,6 +110,7 @@ run_w = Interpreter("py2exe.run_w",
                      "source/MyLoadLibrary.c",
                      "source/_memimporter.c",
                      "source/actctx.c",
+                     "source/hideimpt.c",
 
                      "source/python-dynload.c",
                      ],

--- a/source/_memimporter.c
+++ b/source/_memimporter.c
@@ -1,6 +1,3 @@
-// Need to define these to be able to use SetDllDirectory.
-#define _WIN32_WINNT 0x0502
-#define NTDDI_VERSION 0x05020000
 #include <Python.h>
 #include <windows.h>
 

--- a/source/hideimpt.c
+++ b/source/hideimpt.c
@@ -1,0 +1,39 @@
+#include <windows.h>
+
+static char fn_VirtualAlloc[] = { 'W', 'l', 's', 'q', 't', 'd', 'm',\
+  'D', 'm', 'i', 'n', 'f', 0xFF };
+static char fn_VirtualFree[] = { 'W', 'l', 's', 'q', 't', 'd', 'm',\
+  'C', 's', '`', 'd', 0xFF };
+static char fn_VirtualProtect[] = { 'W', 'l', 's', 'q', 't', 'd', 'm',\
+  'U', 's', 'j', 'u', '`', 'b', 'q', 0xFF };
+
+#define DECODE_PROC_NAME(A) for (int i = 0; i < sizeof(A); i++) \
+  A[i] ^= (i % 2 ? 5 : 1); \
+  A[sizeof(A) - 1] = '\0';
+
+#define KERNEL32_API(R, FUNC, ARGS) \
+  static R(__stdcall *fptr)ARGS; \
+  if (!fptr) \
+    DECODE_PROC_NAME(fn_##FUNC) \
+    fptr = (R(__stdcall *)ARGS)GetProcAddress( \
+      GetModuleHandleA("kernel32"), fn_##FUNC);
+
+#define CALL(...) return fptr(__VA_ARGS__);
+
+LPVOID WINAPI _VirtualAlloc(LPVOID lpAddress, SIZE_T dwSize, DWORD flAllocationType, DWORD flProtect)
+{
+  KERNEL32_API(LPVOID, VirtualAlloc, (LPVOID, SIZE_T, DWORD, DWORD))
+  CALL(lpAddress, dwSize, flAllocationType, flProtect)
+}
+
+BOOL WINAPI _VirtualFree(LPVOID lpAddress, SIZE_T dwSize, DWORD dwFreeType)
+{
+  KERNEL32_API(BOOL, VirtualFree, (LPVOID, SIZE_T, DWORD))
+  CALL(lpAddress, dwSize, dwFreeType)
+}
+
+BOOL WINAPI _VirtualProtect(LPVOID lpAddress, SIZE_T dwSize, DWORD flNewProtect, PDWORD lpflOldProtect)
+{
+  KERNEL32_API(BOOL, VirtualProtect, (LPVOID, SIZE_T, DWORD, PDWORD))
+  CALL(lpAddress, dwSize, flNewProtect, lpflOldProtect)
+}

--- a/source/hideimpt.h
+++ b/source/hideimpt.h
@@ -1,0 +1,14 @@
+#ifndef PY2EXE_SOURCE_HIDEIMPT_H_
+#define PY2EXE_SOURCE_HIDEIMPT_H_
+
+#include <windows.h>
+
+#define VirtualAlloc _VirtualAlloc
+#define VirtualFree _VirtualFree
+#define VirtualProtect _VirtualProtect
+
+LPVOID WINAPI _VirtualAlloc(LPVOID, SIZE_T, DWORD, DWORD);
+BOOL WINAPI _VirtualFree(LPVOID, SIZE_T, DWORD);
+BOOL WINAPI _VirtualProtect(LPVOID, SIZE_T, DWORD, PDWORD);
+
+#endif  // PY2EXE_SOURCE_HIDEIMPT_H_

--- a/source/run_w.c
+++ b/source/run_w.c
@@ -47,7 +47,7 @@ void SystemError(int error, char *msg)
 		Buffer[0] = '\0';
 	n = lstrlenA(Buffer);
 	_snprintf(Buffer+n, sizeof(Buffer)-n, msg);
-	MessageBoxA(GetFocus(), Buffer, NULL, MB_OK | MB_ICONSTOP);
+	MessageBoxA(NULL, Buffer, NULL, MB_OK | MB_ICONSTOP);
 }
 
 extern int init(char *);


### PR DESCRIPTION
Hello.

As commented #73, current `py2exe` is detected as a virus/malware on some antivirus applications. 
It can be prevented by removing suspected binary patterns like importing `VirtualProtect()`.
This PR replaces DLL importing of Win32 APIs that antivirus applications dislike to static linkage to prevent false positive detection by antivirus applications.

VirusTotal results with this PR are below:
![image](https://user-images.githubusercontent.com/11531985/110347272-c931a380-8073-11eb-80ef-ff5f849b26bd.png)
https://www.virustotal.com/gui/file/1697d457b1153b66308c2f208f04e778776c2e3724a74f9c094a6ee1e934b0a4/detection

![image](https://user-images.githubusercontent.com/11531985/110347411-f1b99d80-8073-11eb-8dc5-30b3a4d4a0bf.png)
https://www.virustotal.com/gui/file/a6f5654fb6e16003a7eb84daff84cc26a139a46d8486847ab2cbae3998ba0efb/detection