### PR TITLE
add wxPython functional test

### DIFF
--- a/tests/functional/wxPython_test/requirements.txt
+++ b/tests/functional/wxPython_test/requirements.txt
@@ -1,0 +1,1 @@
+wxPython

--- a/tests/functional/wxPython_test/setup.py
+++ b/tests/functional/wxPython_test/setup.py
@@ -1,0 +1,7 @@
+from distutils.core import setup
+import py2exe
+
+setup(
+    console = [{"script": "wxPython_test.py"}],
+    options={"py2exe": {"packages": ['wx']}},
+    )

--- a/tests/functional/wxPython_test/wxPython_test.py
+++ b/tests/functional/wxPython_test/wxPython_test.py
@@ -1,0 +1,6 @@
+import wx
+app = wx.App()
+frame = wx.Frame(None,title='hello')
+title = frame.GetTitle()
+print(title)
+assert title == 'hello'


### PR DESCRIPTION
I'm not familiar with CI in github but I added a simple functional test for wxPython
Note that this test should now FAIL because of the "packages":["wx"] option
Removing this option should have the test pass