### PR TITLE
- check that DLL is already loaded using correct key.

### DIFF
--- a/py2exe/dllfinder.py
+++ b/py2exe/dllfinder.py
@@ -78,10 +78,10 @@ class DllFinder:
 
         while todo:
             dll = todo.pop() # get one and check it
-            if dll in self._loaded_dlls:
+            if os.path.basename(dll).lower() in self._loaded_dlls:
                 continue
             for dep_dll in self.bind_image(dll):
-                if dep_dll in self._loaded_dlls:
+                if os.path.basename(dep_dll).lower() in self._loaded_dlls:
                     continue
                 dll_type = self.determine_dll_type(dep_dll)
                 if dll_type is None:


### PR DESCRIPTION
Correctly check that DLL is already loaded - _loaded_dlls is a mapping basename(dllname).lower() ==> full dll path.