### PR TITLE
Let patched sys.stderr.write() and sys.stdout.write() return number of written bytes

### DIFF
--- a/py2exe/boot_common.py
+++ b/py2exe/boot_common.py
@@ -71,8 +71,11 @@ if sys.frozen == "windows_exe":
                                     "Errors in %r" % os.path.basename(sys.executable),
                                     0)
             if self._file is not None:
-                self._file.write(text)
+                n_written = self._file.write(text)
                 self._file.flush()
+                return n_written
+            else:
+                return len(text)
         def flush(self):
             if self._file is not None:
                 self._file.flush()
@@ -82,7 +85,7 @@ if sys.frozen == "windows_exe":
     class Blackhole(object):
         softspace = 0
         def write(self, text):
-            pass
+            return len(text)
         def flush(self):
             pass
     sys.stdout = Blackhole()


### PR DESCRIPTION
On Python 3, a file’s write() method is expected to return the number of
written bytes.

It’s a bit unclear what do when no data is actually written (log file
couldn’t be opened in case of stderr or data is deliberately ignored in
case of stdout). I think it’s reasonable in this case to pretend that
all passed data was written. If we returned 0, a caller which calls
write() repeatedly until all data has been written will end up in an
infinite loop.