### PR TITLE
Add missing definitions used with debug build

### DIFF
--- a/source/python-dynload.c
+++ b/source/python-dynload.c
@@ -305,6 +305,18 @@ PyObject *PyUnicode_FromString(const char *u)
   return proc(u);
 }
 
+#ifdef Py_REF_DEBUG
+
+Py_ssize_t _Py_RefTotal;
+
+void _Py_NegativeRefcount(const char *filename, int lineno, PyObject *op)
+{
+  FUNC(void, _Py_NegativeRefcount, (const char *, int, PyObject *));
+  proc(filename, lineno, op);
+}
+
+#endif
+
 #undef _Py_Dealloc
 
 void _Py_Dealloc(PyObject *op)


### PR DESCRIPTION
There are some compilation errors when py2exe is built in debug mode:
```
python_d setup.py build --debug
...
   Creating library build\temp.win-amd64-cpython-310-pydebug\Debug\source\run_d-py3.10-win-amd64.lib and object build\temp.win-amd64-cpython-310-pydebug\Debug\source\run_d-py3.10-win-amd64.exp
start.obj : error LNK2001: unresolved external symbol _Py_NegativeRefcount
MyLoadLibrary.obj : error LNK2001: unresolved external symbol _Py_NegativeRefcount
_memimporter.obj : error LNK2001: unresolved external symbol _Py_NegativeRefcount
start.obj : error LNK2001: unresolved external symbol _Py_RefTotal
MyLoadLibrary.obj : error LNK2001: unresolved external symbol _Py_RefTotal
_memimporter.obj : error LNK2001: unresolved external symbol _Py_RefTotal
build\lib.win-amd64-cpython-310-pydebug\py2exe\run_d-py3.10-win-amd64.exe : fatal error LNK1120: 2 unresolved externals
```
Added the missing definitions taken from object.h:
```cpp
#ifdef Py_REF_DEBUG
PyAPI_DATA(Py_ssize_t) _Py_RefTotal;
PyAPI_FUNC(void) _Py_NegativeRefcount(const char *filename, int lineno,
                                      PyObject *op);
#endif /* Py_REF_DEBUG */
```