### PR TITLE
source: add missing #ifndef

### DIFF
--- a/source/_memimporter.c
+++ b/source/_memimporter.c
@@ -207,8 +207,10 @@ import_module(PyObject *self, PyObject *args)
 	#endif
 
 	hmem = MyLoadLibrary(pathname, NULL, 0, findproc);
+	#ifndef STANDALONE
 	if (res)
 		SetDllDirectory(NULL); // restore the default dll directory search path
+	#endif
 	_My_DeactivateActCtx(cookie);
 
 	if (!hmem) {


### PR DESCRIPTION
Fix which due to "warning C4700: uninitialized local variable 'res' used"