### PR TITLE
Reintroduce ability to specify different version info for each of the frozen binaries.

### DIFF
--- a/docs/py2exe.freeze.md
+++ b/docs/py2exe.freeze.md
@@ -32,6 +32,7 @@ Target dictionaries (to be used for `console` or `windows`):
  - <b>`bitmap_resources`</b> (list):  list of 2-tuples `(id, pathname)`.  Bitmap files added in the bundle. 
  - <b>`icon_resources`</b> (list):  list of 2-tuples `(id, pathname)`  Icon used for the executable. 
  - <b>`other_resources`</b> (list):  list of 3-tuples `(resource_type, id, datastring)`  Other files added in the bundle. 
+ - <b>`version_info`</b> (dict):  optionally specifies version information for a given binary.  Supported values are listed below. 
 
 Options (`options`): 
  - <b>`includes`</b> (list):  list of modules to include in the bundle. 
@@ -52,7 +53,7 @@ Bundle files levels (`bundle_files`): The py2exe runtime *can* use extension mod
  - <b>`bundle_files == 1`</b>:  Extension modules and the Python DLL are put into  the zipfile or the EXE/DLL files, and everything is loaded without unpacking to  the file system.  This does not work for some DLLs, so use with  caution. 
  - <b>`bundle_files == 0`</b>:  Extension modules, the Python DLL, and other needed DLLs are put  into the zipfile or the EXE/DLL files, and everything is loaded  without unpacking to the file system.  This does not work for  some DLLs, so use with caution. 
 
-Version information (`version_info`): Information passed in this dictionary are attached to the frozen executable and displayed in its Properties -> Details view. Supported keys: 
+Version information (`version_info`): Information passed in this dictionary are attached to all frozen executables and displayed in its Properties -> Details view. If you need to specify different version information for each of the frozen binaries you should add `version_info` dictionary to each of the `windows` and `console targets. Supported keys: 
  - <b>`version`</b> (str):  version number 
  - <b>`description`</b> (str):  - 
  - <b>`comments`</b> (str):  - 

--- a/py2exe/runtime.py
+++ b/py2exe/runtime.py
@@ -367,9 +367,9 @@ class Runtime(object):
                 res_writer.add(type=res_type, name=res_name, value=res_data)
 
             # Build and add a versioninfo resource - freeze interface only
-            if hasattr(self.options, "version_info") and self.options.version_info:
-                self.options.version_info.original_filename = os.path.basename(exe_path)
-                version = Version(self.options.version_info)
+            if hasattr(target, "version_info") and target.version_info:
+                target.version_info.original_filename = os.path.basename(exe_path)
+                version = Version(target.version_info)
 
                 from ._wapi import RT_VERSION
                 res_writer.add(type=RT_VERSION,

--- a/tests/_helpers/file_info_utils.py
+++ b/tests/_helpers/file_info_utils.py
@@ -1,0 +1,16 @@
+import pefile
+
+
+def get_file_version_info(file_name):
+    """Borrowed from https://stackoverflow.com/questions/580924/how-to-access-a-files-properties-on-windows"""
+    pe = pefile.PE(file_name, fast_load=True)
+    pe.parse_data_directories(directories=[pefile.DIRECTORY_ENTRY['IMAGE_DIRECTORY_ENTRY_RESOURCE']])
+    res = {}
+    for idx in range(len(pe.VS_VERSIONINFO)):
+        if hasattr(pe, 'FileInfo') and len(pe.FileInfo) > idx:
+            for entry in pe.FileInfo[idx]:
+                if hasattr(entry, 'StringTable'):
+                    for st_entry in entry.StringTable:
+                        for str_entry in sorted(list(st_entry.entries.items())):
+                            res[str_entry[0].decode('utf-8', 'backslashreplace')]  = str_entry[1].decode('utf-8', 'backslashreplace')
+    return res

--- a/tests/functional/two_binaries_different_version_info_test/freeze.py
+++ b/tests/functional/two_binaries_different_version_info_test/freeze.py
@@ -1,0 +1,36 @@
+import os
+import sys
+
+from py2exe import freeze
+
+sys.path.append(os.path.join("..", "..", "_helpers"))  # So that file version utils can be found when freezing.
+
+
+freeze(
+    console=[
+        {
+            "script": "two_binaries_different_version_info_test_1.py",
+            "version_info": {
+                "version": "1.1.1",
+                "description": "Binary's 1 description",
+                "comments": "Comments for binary 1",
+                "company_name": "Binary 1 developers and testers",
+                "copyright": "2023 - binary1  author",
+                "product_name": "Binary 1",
+                "product_version": "1.1.1",
+            }
+        },
+        {
+            "script": "two_binaries_different_version_info_test_2.py",
+            "version_info": {
+                "version": "2.2.2",
+                "description": "Binary's 2 description",
+                "comments": "Comments for binary 2",
+                "company_name": "Binary 2 developers and testers",
+                "copyright": "2023 - binary2  author",
+                "product_name": "Binary 2",
+                "product_version": "2.2.2",
+            }
+        }
+    ],
+)

--- a/tests/functional/two_binaries_different_version_info_test/two_binaries_different_version_info_test_1.py
+++ b/tests/functional/two_binaries_different_version_info_test/two_binaries_different_version_info_test_1.py
@@ -1,0 +1,11 @@
+import sys
+import file_info_utils
+
+file_data = file_info_utils.get_file_version_info(sys.executable)
+assert file_data["ProductVersion"] == "1.1.1"
+assert file_data["FileDescription"] == "Binary's 1 description"
+assert file_data["Comments"] == "Comments for binary 1"
+assert file_data["CompanyName"] == "Binary 1 developers and testers"
+assert file_data["LegalCopyright"] == "2023 - binary1  author"
+assert file_data["ProductName"] == "Binary 1"
+assert file_data["FileVersion"] == "1.1.1"

--- a/tests/functional/two_binaries_different_version_info_test/two_binaries_different_version_info_test_2.py
+++ b/tests/functional/two_binaries_different_version_info_test/two_binaries_different_version_info_test_2.py
@@ -1,0 +1,11 @@
+import sys
+import file_info_utils
+
+file_data = file_info_utils.get_file_version_info(sys.executable)
+assert file_data["ProductVersion"] == "2.2.2"
+assert file_data["FileDescription"] == "Binary's 2 description"
+assert file_data["Comments"] == "Comments for binary 2"
+assert file_data["CompanyName"] == "Binary 2 developers and testers"
+assert file_data["LegalCopyright"] == "2023 - binary2  author"
+assert file_data["ProductName"] == "Binary 2"
+assert file_data["FileVersion"] == "2.2.2"

--- a/tests/functional/two_binaries_single_version_info_test/freeze.py
+++ b/tests/functional/two_binaries_single_version_info_test/freeze.py
@@ -1,0 +1,20 @@
+import os
+import sys
+
+from py2exe import freeze
+
+sys.path.append(os.path.join("..", "..", "_helpers"))  # So that file version utils can be found when freezing.
+
+
+freeze(
+    console=[{"script": "two_binaries_single_version_info_test_1.py"}, {"script": "two_binaries_single_version_info_test_2.py"}],
+    version_info={
+        "version": "1.2.3",
+        "description": "My binary",
+        "comments": "Comments for my binary",
+        "company_name": "My avesome company",
+        "copyright": "2023 - binary author",
+        "product_name": "Sample binary",
+        "product_version": "1.2.3",
+    }
+)

--- a/tests/functional/two_binaries_single_version_info_test/two_binaries_single_version_info_test_1.py
+++ b/tests/functional/two_binaries_single_version_info_test/two_binaries_single_version_info_test_1.py
@@ -1,0 +1,11 @@
+import sys
+import file_info_utils
+
+file_data = file_info_utils.get_file_version_info(sys.executable)
+assert file_data["ProductVersion"] == "1.2.3"
+assert file_data["FileDescription"] == "My binary"
+assert file_data["Comments"] == "Comments for my binary"
+assert file_data["CompanyName"] == "My avesome company"
+assert file_data["LegalCopyright"] == "2023 - binary author"
+assert file_data["ProductName"] == "Sample binary"
+assert file_data["FileVersion"] == "1.2.3"

--- a/tests/functional/two_binaries_single_version_info_test/two_binaries_single_version_info_test_2.py
+++ b/tests/functional/two_binaries_single_version_info_test/two_binaries_single_version_info_test_2.py
@@ -1,0 +1,11 @@
+import sys
+import file_info_utils
+
+file_data = file_info_utils.get_file_version_info(sys.executable)
+assert file_data["ProductVersion"] == "1.2.3"
+assert file_data["FileDescription"] == "My binary"
+assert file_data["Comments"] == "Comments for my binary"
+assert file_data["CompanyName"] == "My avesome company"
+assert file_data["LegalCopyright"] == "2023 - binary author"
+assert file_data["ProductName"] == "Sample binary"
+assert file_data["FileVersion"] == "1.2.3"


### PR DESCRIPTION
Fixes #193

It is once again possible to specify different version info for each of the frozen binaries, by specifying `version_info` dictionary for each of the targets. I have also added functional tests confirming that by default `version_info` provided as parameter is used, and that values from the per target `version_info` are added to the binaries when present. While at it I have also modified tests runner, so that it is possible to execute only a single test by name.