### PR TITLE
Fix build with setuptools v70.0.0

### DIFF
--- a/py2exe_setuptools.py
+++ b/py2exe_setuptools.py
@@ -7,7 +7,11 @@ from setuptools.command import build
 from setuptools.command.build_ext import build_ext
 from setuptools.dist import Distribution
 from setuptools.extension import Extension
-from setuptools.dep_util import newer_group
+try:
+    # available since setuptools v69.0.0
+    from setuptools.modified import newer_group
+except ImportError:
+    from setuptools.dep_util import newer_group
 from setuptools.errors import CCompilerError, CompileError, PlatformError, SetupError
 
 from sysconfig import get_platform


### PR DESCRIPTION
Setuptools v70.0.0 removed the setuptools.dep_util module and added a replacement called setuptools.modified. The replacement exists since v69.0.0.

To avoid dropping support for older setuptools (in case people have pinned it due to this issue) try the old name too if needed.

Fixes #208