### PR TITLE
Exclude python core dynload on python 3.12+.

### DIFF
--- a/source/Python-dynload.h
+++ b/source/Python-dynload.h
@@ -1,3 +1,4 @@
+#if (PY_VERSION_HEX < 0x030C0000)
 #define Py_OptimizeFlag *(_Py_OptimizeFlag_PTR())
 #define Py_NoSiteFlag *(_Py_NoSiteFlag_PTR())
 #define Py_VerboseFlag *(_Py_VerboseFlag_PTR())
@@ -11,3 +12,4 @@ extern char **__Py_PackageContext_PTR();
 extern PyTypeObject *PyModuleDef_Type_PTR();
 
 extern int PythonLoaded(HMODULE hmod);
+#endif

--- a/source/python-dynload.c
+++ b/source/python-dynload.c
@@ -4,6 +4,20 @@
 #include "Python-dynload.h"
 
 /*
+ * In Python 3.12+ dynamically loading the python core DLL
+ * is no longer supported due to needing to load TLS Data
+ * and loading the TLS Data when memory loading the core dll
+ * is impossible due to the ntdll.dll symbol known as
+ * LdrpHandleTlsData is both undocumented and is not exported.
+ * Likewise, the address to the function is not guaranteed to
+ * to stay at it's specific memory address on each revision of
+ * Windows and can result in immediate crash when trying to call
+ * that particular function from C/C++ code. That is if the function
+ * does not get removed and/or renamed at best, at worst it being a
+ * missing function. Basically it causes Undefined Behavior.
+ */
+#if (PY_VERSION_HEX < 0x030C0000)
+/*
   This module allows us to dynamically load the python DLL.
 
   We have to #define Py_BUILD_CORE when we cmpile our stuff,
@@ -529,3 +543,4 @@ PyObject *PyExc_ImportError;
 PyObject *PyExc_RuntimeError;
 
 //Py_VerboseFlag
+#endif

--- a/source/start.c
+++ b/source/start.c
@@ -205,7 +205,7 @@ int run_script(void)
 	return rc;
 }
 
-
+#if (PY_VERSION_HEX < 0x030C0000)
 /* XXX XXX XXX flags should be set elsewhere */
 /*
   c:\Python34\include\Python.h
@@ -301,12 +301,12 @@ HMODULE load_pythondll(void)
 	FreeLibrary(hmod);
 	return hmod_pydll;
 }
+#endif
 
 int init_with_instance(HMODULE hmod_exe, char *frozen, int argc, wchar_t **argv)
 {
 
 	int rc = 0;
-	HMODULE hmod_pydll;
 
 //	Py_NoSiteFlag = 1; /* Suppress 'import site' */
 //	Py_InspectFlag = 1; /* Needed to determine whether to exit at SystemExit */
@@ -321,7 +321,8 @@ int init_with_instance(HMODULE hmod_exe, char *frozen, int argc, wchar_t **argv)
 		return -1;
 	}
 
-	hmod_pydll = load_pythondll();
+#if (PY_VERSION_HEX < 0x030C0000)
+	HMODULE hmod_pydll = load_pythondll();
 	if (hmod_pydll == NULL) {
 		SystemError(-1, "FATAL ERROR: Could not load python library");
 //		printf("FATAL Error: could not load python library\n");
@@ -334,6 +335,7 @@ int init_with_instance(HMODULE hmod_exe, char *frozen, int argc, wchar_t **argv)
 	}
 
 	set_vars(hmod_pydll);
+#endif
 
 	/*
 	  _memimporter contains the magic which allows to load


### PR DESCRIPTION
Since the python core dynamic loading code cannot be made to work for Python 3.12+. The related code for loading the python core from zip file/resource section has been ifdef'd out. As such single file deployments for Python 3.12+ is not possible at all.

Contributes to #191.