### PR TITLE
Prevent DllFinder.bind_image from returning None values

### DIFF
--- a/py2exe/dllfinder.py
+++ b/py2exe/dllfinder.py
@@ -137,7 +137,8 @@ class DllFinder:
                     if img_name.decode("mbcs") == name:
                         # name binds to dllname
                         dllname = self.search_path(dllname.decode("mbcs"), path)
-                        TEMP.add(dllname)
+                        if dllname is not None:
+                            TEMP.add(dllname)
                 return True
 
             # BindImageEx uses the PATH environment variable to find


### PR DESCRIPTION
When running `py2exe` using [Wine](https://www.winehq.org/), it crashes because some `None` values are returned by `DllFinder.bind_image`.

This pull request fixes this issue.