### PR TITLE
Add hook for pyphen

### DIFF
--- a/py2exe/hooks.py
+++ b/py2exe/hooks.py
@@ -246,6 +246,34 @@ def hook__socket(finder, module):
     if sys.version_info >= (3,6,0) and sys.version_info < (3,12,0):
         finder.import_hook("imp")
 
+def hook_pyphen(finder, module):
+    """pyphen locates its dictionary files via importlib.resources or __file__,
+    neither of which works inside a frozen library.zip.
+    This hook copies hyph_*.dic files next to the executable and patches
+    pyphen.dictionaries to resolve from there at runtime.
+    """
+    import pyphen
+    import glob as _glob
+    DEST_DIR = "pyphenDictionaries"
+    source_dir = os.path.join(os.path.dirname(pyphen.__file__), "dictionaries")
+    for dic_file in _glob.glob(os.path.join(source_dir, "hyph_*.dic")):
+        finder.add_datafile(
+            os.path.join(DEST_DIR, os.path.basename(dic_file)),
+            dic_file,
+        )
+    finder.add_bootcode("""
+def _patch_pyphen():
+    import pyphen
+    import os
+    import sys
+    from pathlib import Path
+    pyphen.dictionaries = Path(os.path.dirname(sys.executable)) / "pyphenDictionaries"
+
+_patch_pyphen()
+del _patch_pyphen
+""")
+
+
 def hook_pyreadline(finder, module):
     """
     """


### PR DESCRIPTION
## Summary

- Adds `hook_pyphen` to bundle `hyph_*.dic` dictionary files next to the frozen executable
- Patches `pyphen.dictionaries` at runtime via bootcode so pyphen resolves dictionaries from the correct path instead of the non-functional `importlib.resources` / `__file__` paths inside `library.zip`

## Problem

pyphen locates its dictionary files at module init time via:

```python
try:
    dictionaries = resources.files('pyphen.dictionaries')
except TypeError:
    dictionaries = Path(__file__).parent / 'dictionaries'
```

After freezing, pyphen lives inside `library.zip`. `resources.files()` fails silently or returns a broken path, and `__file__` no longer points to the filesystem. As a result `pyphen.LANGUAGES` is empty and hyphenation does not work.

## Solution

The hook:
1. Copies every `hyph_*.dic` file from pyphen's `dictionaries/` folder into `pyphenDictionaries/` next to the executable via `finder.add_datafile`
2. Injects bootcode that sets `pyphen.dictionaries` to `Path(os.path.dirname(sys.executable)) / "pyphenDictionaries"` after pyphen is imported

See also https://github.com/nvaccess/nvda/pull/20145